### PR TITLE
Fixes issue #97

### DIFF
--- a/src/main/java/com/aitusoftware/babl/websocket/FrameDecoder.java
+++ b/src/main/java/com/aitusoftware/babl/websocket/FrameDecoder.java
@@ -394,7 +394,7 @@ final class FrameDecoder
         payloadLength = frameHeader.maskedPayloadLength;
         if (frameHeader.frameSize == FrameSize.MEDIUM)
         {
-            payloadLength = (int)Integer.toUnsignedLong(srcBuffer.getShort(2, NETWORK_BYTE_ORDER));
+            payloadLength = (int)Short.toUnsignedLong(srcBuffer.getShort(2, NETWORK_BYTE_ORDER));
         }
         else if (frameHeader.frameSize == FrameSize.LARGE)
         {


### PR DESCRIPTION
Fix for [](https://github.com/babl-ws/babl/issues/97)
The code was using Integer.toUnsignedLong for a short value which broke decoding for mid-sized packets.