### PR TITLE
expose request uri on sesion connect

### DIFF
--- a/src/jmh/java/com/aitusoftware/babl/websocket/WebSocketSessionBenchmark.java
+++ b/src/jmh/java/com/aitusoftware/babl/websocket/WebSocketSessionBenchmark.java
@@ -69,8 +69,10 @@ public class WebSocketSessionBenchmark
     private final FrameDecoder frameDecoder = new FrameDecoder(
         messageDispatcher, SESSION_CONFIG, bufferPool, pingAgent, false, SESSION_CONTAINER_STATISTICS);
     private final ByteBuffer singleFramePayload = ByteBuffer.allocateDirect(106);
+    private final StringBuilder requestUri = new StringBuilder(64);
     private final WebSocketSession session = new WebSocketSession(SESSION_DATA_LISTENER, frameDecoder, frameEncoder,
-        SESSION_CONFIG, bufferPool, application, pingAgent, CLOCK, SESSION_STATISTICS, SESSION_CONTAINER_STATISTICS);
+        SESSION_CONFIG, bufferPool, application, pingAgent, CLOCK, requestUri, SESSION_STATISTICS,
+        SESSION_CONTAINER_STATISTICS);
     private final DataSource dataSource = new DataSource();
     private final DataSink dataSink = new DataSink();
 
@@ -190,7 +192,7 @@ public class WebSocketSessionBenchmark
         }
 
         @Override
-        boolean handleUpgrade(final ByteBuffer input, final ByteBuffer output)
+        boolean handleUpgrade(final ByteBuffer input, final ByteBuffer output, final StringBuilder outputRequestUri)
         {
             return true;
         }

--- a/src/main/java/com/aitusoftware/babl/proxy/ApplicationAdapter.java
+++ b/src/main/java/com/aitusoftware/babl/proxy/ApplicationAdapter.java
@@ -186,12 +186,14 @@ public final class ApplicationAdapter implements Agent, ControlledFragmentHandle
         sessionOpenDecoder.wrap(buffer, offset + MessageHeaderDecoder.ENCODED_LENGTH,
             messageHeaderDecoder.blockLength(), messageHeaderDecoder.version());
         final long sessionId = sessionOpenDecoder.sessionId();
+        final VarDataEncodingDecoder decodedRequestUri = sessionOpenDecoder.requestUri();
         SessionProxy sessionProxy = sessionProxyById.get(sessionId);
         if (sessionProxy == null)
         {
             sessionProxy = sessionProxyObjectPool.acquire();
             sessionProxyById.put(sessionId, sessionProxy);
-            sessionProxy.set(sessionId, sessionOpenDecoder.containerId());
+            sessionProxy.set(sessionId, sessionOpenDecoder.containerId(), decodedRequestUri.buffer(),
+                decodedRequestUri.offset() + varDataEncodingOffset(), (int)decodedRequestUri.length());
         }
         else
         {

--- a/src/main/java/com/aitusoftware/babl/proxy/SessionProxy.java
+++ b/src/main/java/com/aitusoftware/babl/proxy/SessionProxy.java
@@ -58,6 +58,7 @@ final class SessionProxy implements Session, Pooled
     private long sessionId;
     private int sessionContainerId;
     private Publication currentServerPublication;
+    private StringBuilder requestUri = new StringBuilder(64);
 
     SessionProxy(
         final Publication[] publications,
@@ -72,6 +73,19 @@ final class SessionProxy implements Session, Pooled
         this.sessionId = sessionId;
         this.sessionContainerId = sessionContainerId;
         currentServerPublication = toServerPublications[sessionContainerId];
+    }
+
+    void set(
+        final long sessionId,
+        final int sessionContainerId,
+        final DirectBuffer requestUri,
+        final int offset,
+        final int length)
+    {
+        this.sessionId = sessionId;
+        this.sessionContainerId = sessionContainerId;
+        currentServerPublication = toServerPublications[sessionContainerId];
+        requestUri.getStringWithoutLengthAscii(offset, length, this.requestUri);
     }
 
     @Override
@@ -137,10 +151,17 @@ final class SessionProxy implements Session, Pooled
     }
 
     @Override
+    public CharSequence requestUri()
+    {
+        return requestUri;
+    }
+
+    @Override
     public void reset()
     {
         this.sessionId = Long.MIN_VALUE;
         this.sessionContainerId = Integer.MIN_VALUE;
+        this.requestUri.setLength(0);
     }
 
     @Override

--- a/src/main/java/com/aitusoftware/babl/websocket/Session.java
+++ b/src/main/java/com/aitusoftware/babl/websocket/Session.java
@@ -30,5 +30,7 @@ public interface Session
 
     long id();
 
+    CharSequence requestUri();
+
     int close(DisconnectReason disconnectReason);
 }

--- a/src/main/java/com/aitusoftware/babl/websocket/SessionFactory.java
+++ b/src/main/java/com/aitusoftware/babl/websocket/SessionFactory.java
@@ -71,10 +71,11 @@ final class SessionFactory implements Supplier<WebSocketSession>
             TimeUnit.NANOSECONDS.toMillis(sessionConfig.pongResponseTimeoutNanos()), perSessionDataListener);
         final FrameDecoder frameDecoder = new FrameDecoder(new MessageDispatcher(application), sessionConfig,
             bufferPool, pingAgent, true, sessionContainerStatistics);
+        final StringBuilder requestUri = new StringBuilder(64);
 
         return new WebSocketSession(
             perSessionDataListener, frameDecoder,
             frameEncoder, sessionConfig, bufferPool, application, pingAgent,
-            sharedClock, sessionStatistics, sessionContainerStatistics);
+            sharedClock, requestUri, sessionStatistics, sessionContainerStatistics);
     }
 }

--- a/src/main/java/com/aitusoftware/babl/websocket/WebSocketSession.java
+++ b/src/main/java/com/aitusoftware/babl/websocket/WebSocketSession.java
@@ -67,6 +67,7 @@ public final class WebSocketSession implements Pooled, Session
     private SessionStatistics sessionStatistics;
     private transient ByteBuffer handshakeSendBuffer;
     private ByteBuffer receiveBuffer;
+    private StringBuilder requestUri;
     private SessionState state = SessionState.UPGRADING;
     private boolean closed = true;
     private short closeReason = NULL_CLOSE_REASON;
@@ -86,6 +87,7 @@ public final class WebSocketSession implements Pooled, Session
         final Application application,
         final PingAgent pingAgent,
         final EpochClock epochClock,
+        final StringBuilder requestUri,
         final SessionStatistics sessionStatistics,
         final SessionContainerStatistics sessionContainerStatistics)
     {
@@ -97,6 +99,7 @@ public final class WebSocketSession implements Pooled, Session
         this.application = application;
         this.pingAgent = pingAgent;
         this.epochClock = epochClock;
+        this.requestUri = requestUri;
         this.sessionStatistics = sessionStatistics;
         this.sessionContainerStatistics = sessionContainerStatistics;
     }
@@ -120,6 +123,7 @@ public final class WebSocketSession implements Pooled, Session
         }
         selectionKey = null;
         closingTimestampMs = 0L;
+        requestUri.setLength(0);
     }
 
     void init(
@@ -176,6 +180,12 @@ public final class WebSocketSession implements Pooled, Session
     public long id()
     {
         return id;
+    }
+
+    @Override
+    public CharSequence requestUri()
+    {
+        return requestUri;
     }
 
     @Override
@@ -441,7 +451,7 @@ public final class WebSocketSession implements Pooled, Session
         }
         Logger.log(Category.CONNECTION, "Session %d attempting upgrade with %d available bytes%n",
             id, receiveBuffer.limit());
-        if (connectionUpgrade.handleUpgrade(receiveBuffer, handshakeSendBuffer))
+        if (connectionUpgrade.handleUpgrade(receiveBuffer, handshakeSendBuffer, requestUri))
         {
             Logger.log(Category.CONNECTION, "Session %d upgraded%n", id);
             setState(SessionState.VALIDATING);

--- a/src/main/resources/sbe-schema.xml
+++ b/src/main/resources/sbe-schema.xml
@@ -40,6 +40,7 @@
     <sbe:message name="SessionOpened" id="1" description="Session opened event">
         <field name="sessionId" id="1" type="int64"/>
         <field name="containerId" id="2" type="int32"/>
+        <field name="requestUri" id="3" type="varDataEncoding"/>
     </sbe:message>
     <sbe:message name="SessionClosed" id="2" description="Session closed event">
         <field name="sessionId" id="1" type="int64"/>

--- a/src/test/java/com/aitusoftware/babl/proxy/ProxyIntegrationTest.java
+++ b/src/test/java/com/aitusoftware/babl/proxy/ProxyIntegrationTest.java
@@ -27,6 +27,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -96,12 +97,12 @@ class ProxyIntegrationTest
     private final MutableDirectBuffer payload = new UnsafeBuffer(new byte[PAYLOAD_LENGTH]);
     private final Session session = mock(Session.class);
     private final Broadcast broadcast = mock(Broadcast.class);
-
     private static final byte PAYLOAD_VALUE = (byte)7;
     private final Application application = mock(Application.class);
 
     {
         Arrays.fill(payload.byteArray(), PAYLOAD_VALUE);
+        when(session.requestUri()).thenReturn("/someendpoint");
     }
 
     @TempDir

--- a/src/test/java/com/aitusoftware/babl/websocket/ConnectionUpgradeTest.java
+++ b/src/test/java/com/aitusoftware/babl/websocket/ConnectionUpgradeTest.java
@@ -33,12 +33,13 @@ class ConnectionUpgradeTest
     private final ConnectionUpgrade connectionUpgrade =
         new ConnectionUpgrade(new ObjectPool<>(ValidationResult::new, 8),
         new AlwaysValidConnectionValidator(), (b) -> true);
+    private final StringBuilder requestUri = new StringBuilder();
 
     @Test
     void shouldHandleConnectionUpgrade()
     {
         final ByteBuffer output = ByteBuffer.allocate(256);
-        connectionUpgrade.handleUpgrade(INPUT, output);
+        connectionUpgrade.handleUpgrade(INPUT, output, requestUri);
 
         assertThat(new String(output.array(), 0, output.remaining())).contains(
             "HTTP/1.1 101 Switching Protocols\r\n" +

--- a/src/test/java/com/aitusoftware/babl/websocket/KeyDecoderTest.java
+++ b/src/test/java/com/aitusoftware/babl/websocket/KeyDecoderTest.java
@@ -122,6 +122,7 @@ class KeyDecoderTest
 
     private final KeyDecoder keyDecoder = new KeyDecoder();
     private byte[] capturedKey;
+    private byte[] capturedUri;
 
     @Test
     void shouldSetBufferPositionAtEndOfHttpRequest()
@@ -163,11 +164,12 @@ class KeyDecoderTest
     {
         final ByteBuffer buffer = ByteBuffer.wrap(httpRequest.getBytes(StandardCharsets.UTF_8));
         assertThat(keyDecoder.decode(
-            buffer, this::captureCharKey))
+            buffer, this::captureCharKey, this::captureRequestUri))
             .isEqualTo(shouldBeDecoded);
         if (shouldBeDecoded)
         {
             assertThat(capturedKey).isEqualTo(WEB_SOCKET_KEY.getBytes(StandardCharsets.UTF_8));
+            assertThat(capturedUri).isEqualTo("/".getBytes(StandardCharsets.UTF_8));
         }
         else
         {
@@ -179,5 +181,10 @@ class KeyDecoderTest
     private void captureCharKey(final CharSequence key)
     {
         capturedKey = key.toString().getBytes(StandardCharsets.US_ASCII);
+    }
+
+    private void captureRequestUri(final CharSequence uri)
+    {
+        capturedUri = uri.toString().getBytes(StandardCharsets.US_ASCII);
     }
 }

--- a/src/test/java/com/aitusoftware/babl/websocket/WebSocketSessionTest.java
+++ b/src/test/java/com/aitusoftware/babl/websocket/WebSocketSessionTest.java
@@ -90,12 +90,13 @@ class WebSocketSessionTest
         bufferPool, sessionDataListener, sessionConfig, sessionContainerStatistics);
     private final PingAgent pingAgent = new PingAgent(
         frameEncoder, clock, PING_INTERVAL_MS, PONG_RESPONSE_TIMEOUT_MS, sessionDataListener);
+    private final StringBuilder requestUri = new StringBuilder(64);
     private final WebSocketSession session = new WebSocketSession(
         sessionDataListener,
         new FrameDecoder(new MessageDispatcher(application), sessionConfig, bufferPool,
         pingAgent, true, sessionContainerStatistics),
-        frameEncoder,
-        sessionConfig, bufferPool, application, pingAgent, clock, sessionStatistics, sessionContainerStatistics);
+        frameEncoder, sessionConfig, bufferPool, application, pingAgent, clock, requestUri,
+        sessionStatistics, sessionContainerStatistics);
     private final UnsafeBuffer applicationBuffer = new UnsafeBuffer(new byte[512]);
     private final SelectionKey selectionKey = mock(SelectionKey.class);
 
@@ -118,13 +119,14 @@ class WebSocketSessionTest
     {
         final EpochClock advancingClock = mock(EpochClock.class, "advancing");
         given(advancingClock.time()).willReturn(BASE_TIME_MS, BASE_TIME_MS + 6_000L);
+        final StringBuilder requestUri = new StringBuilder();
         final WebSocketSession closingSession = new WebSocketSession(
             sessionDataListener,
             new FrameDecoder(
             new MessageDispatcher(application), sessionConfig, bufferPool,
             pingAgent, true, sessionContainerStatistics),
             frameEncoder, sessionConfig, bufferPool, application, pingAgent,
-            advancingClock, sessionStatistics, sessionContainerStatistics);
+            advancingClock, requestUri, sessionStatistics, sessionContainerStatistics);
         closingSession.init(SESSION_ID, connectionUpgrade, cu -> {}, BASE_TIME_MS, channel, channel);
         closingSession.selectionKey(selectionKey);
         closingSession.onCloseMessage((short)1);
@@ -208,7 +210,7 @@ class WebSocketSessionTest
 
         final InOrder order = Mockito.inOrder(sessionDataListener, connectionUpgrade, application);
         order.verify(sessionDataListener).receiveDataAvailable();
-        order.verify(connectionUpgrade).handleUpgrade(any(), any());
+        order.verify(connectionUpgrade).handleUpgrade(any(), any(), any());
         order.verify(sessionDataListener).receiveDataProcessed();
         order.verify(sessionDataListener).receiveDataAvailable();
         order.verify(application).onSessionMessage(
@@ -232,7 +234,7 @@ class WebSocketSessionTest
 
         final InOrder order = Mockito.inOrder(sessionDataListener, connectionUpgrade, application);
         order.verify(sessionDataListener).receiveDataAvailable();
-        order.verify(connectionUpgrade).handleUpgrade(any(), any());
+        order.verify(connectionUpgrade).handleUpgrade(any(), any(), any());
         order.verify(sessionDataListener).receiveDataProcessed();
         order.verify(sessionDataListener).receiveDataAvailable();
         order.verify(application).onSessionMessage(
@@ -264,7 +266,7 @@ class WebSocketSessionTest
 
         final InOrder order = Mockito.inOrder(sessionDataListener, connectionUpgrade, application);
         order.verify(sessionDataListener).receiveDataAvailable();
-        order.verify(connectionUpgrade).handleUpgrade(any(), any());
+        order.verify(connectionUpgrade).handleUpgrade(any(), any(), any());
         order.verify(sessionDataListener).receiveDataProcessed();
         order.verify(sessionDataListener).receiveDataAvailable();
         order.verify(application).onSessionMessage(
@@ -379,7 +381,7 @@ class WebSocketSessionTest
 
         final InOrder order = Mockito.inOrder(sessionDataListener, connectionUpgrade, application);
         order.verify(sessionDataListener).receiveDataAvailable();
-        order.verify(connectionUpgrade).handleUpgrade(any(), any());
+        order.verify(connectionUpgrade).handleUpgrade(any(), any(), any());
         order.verify(sessionDataListener).receiveDataProcessed();
         order.verify(sessionDataListener).receiveDataAvailable();
         order.verify(application).onSessionMessage(
@@ -420,6 +422,6 @@ class WebSocketSessionTest
             final ByteBuffer receiveBuffer = invocation.getArgument(0);
             receiveBuffer.position(receiveBuffer.limit());
             return true;
-        }).when(connectionUpgrade).handleUpgrade(any(), any());
+        }).when(connectionUpgrade).handleUpgrade(any(), any(), any());
     }
 }


### PR DESCRIPTION
This is my attempt on exposing the request uri. I'd appreciate any feedback.

Also a question, I added `requestUri` as type `varDataEncoding` to the `SessionOpened` sbe schema. While there are plenty of examples of encoding/decoding type `varDataEncoding`, I couldn't figure out why it's necessary to add `BitUtil.SIZE_OF_INT` to the message base size.

For example, `TOPIC_MESSAGE_BASE_SIZE` has an extra 4 bytes, `MULTI_TOPIC_MESSAGE_BASE_SIZE` has an extra 8 bytes... They don't seem to belong to `messageHeader` or even `varDataEncoding`. What are these bytes used for?